### PR TITLE
Add support for numeric months

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Tinytime ⏰ 
+# Tinytime ⏰
 > A straightforward date and time formatter in <800b.
 
 <a href="https://www.npmjs.org/package/tinytime">
@@ -24,6 +24,7 @@ template.render(new Date());
 
  * `MMMM` - Full Month (September)
  * `MM` - Partial Month (Sep)
+ * `Mo` - Numeric Month (9)
  * `YYYY` - Full Year (1992)
  * `YY` - Partial Year (92)
  * `dddd` - Day of the Week (Monday)

--- a/__test__/index.spec.js
+++ b/__test__/index.spec.js
@@ -24,6 +24,14 @@ describe('tinytime', () => {
     it('partial months', () => {
       expect(render('{MM}')).toEqual('Sep');
     });
+    it('numeric months', () => {
+      expect(render('{Mo}')).toEqual('9');
+    });
+    it('padded numeric months', () => {
+      const template = tinytime('{Mo}', { padMonth: true })
+      const rendered = template.render(date);
+      expect(rendered).toEqual('09');
+    });
     it('full years', () => {
       expect(render('{YYYY}')).toEqual('1992');
     });

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -3,6 +3,7 @@
 import {
 FullMonth,
 PartialMonth,
+NumberMonth,
 FullYear,
 PartialYear,
 DayOfTheWeek,
@@ -22,7 +23,7 @@ import type { TinyTimeOptions } from './index'
  * removed during build.
  */
 type Days = "Monday" | "Tuesday" | "Wednesday" | "Thursday" | "Friday" | "Saturday" | "Sunday"
-type Month =  "January" | "Febuary" | "March" | "April" | "May" | "June" | "July" | "August" | "September" | "October" | "November" | "December" 
+type Month =  "January" | "Febuary" | "March" | "April" | "May" | "June" | "July" | "August" | "September" | "October" | "November" | "December"
 
 const months: Array<Month> = [
   "January",
@@ -50,7 +51,7 @@ const days: Array<Days> = [
 ]
 
 /**
- * Taks an integer and returns a string left padded with 
+ * Taks an integer and returns a string left padded with
  * a zero to the left. Used to display minutes and hours (1:01:00PM);
  */
 function paddWithZeros(int: number) : string {
@@ -74,8 +75,8 @@ function suffix(int: number): string {
  * The compiler takes in our array of tokens returned from the parser
  * and returns the formed template. It just iterates over the tokens and
  * appends some text to the returned string depending on the type of token.
- * @param {Array<Tokens>} tokens 
- * @param {Date} date 
+ * @param {Array<Tokens>} tokens
+ * @param {Date} date
  * @param {TinyTimeOptions} options
  * @returns {String}
  */
@@ -103,6 +104,13 @@ export default function compiler(tokens: Array<Token>, date: Date, options: Tiny
         break;
       case FullMonth:
         compiled += months[month];
+        break;
+      case NumberMonth:
+        let mnth = month + 1;
+        if (options.padMonth) {
+          mnth = paddWithZeros(mnth);
+        }
+        compiled += mnth;
         break;
       case FullYear:
         compiled += year;

--- a/src/subs.js
+++ b/src/subs.js
@@ -18,6 +18,7 @@ export const Seconds = 'i';
 export const PostOrAnteMeridiem = 'j';
 export const Day = 'k';
 export const DayOfTheMonth = 'l';
+export const NumberMonth = 'n';
 
 
 const SubToTypeIdentifierMap: {
@@ -25,6 +26,7 @@ const SubToTypeIdentifierMap: {
 } = {
   'MMMM': FullMonth,
   'MM': PartialMonth,
+  'Mo': NumberMonth,
   'YYYY': FullYear,
   'YY': PartialYear,
   'dddd': DayOfTheWeek,


### PR DESCRIPTION
It would be nicer to have `MM` for numeric months and `MMM` for partial months, but that would be a breaking change.