### PR TITLE
fix support for padding month

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ type TinyTime = {
 export type TinyTimeOptions = {
   padHours?: boolean,
   padDays?: boolean,
+  padMonth?: boolean,
 }
 
 export default function tinytime(template: string, options: TinyTimeOptions = {}): TinyTime {


### PR DESCRIPTION
PR #5 pretty much added support for padding the numeric months, but they forgot to add `padMonth` to the definition of `TinyTimeOptions` type.

This will also add support for the request in #11 