### PR TITLE
feat: localization, add custom days and months

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Brandon Dail
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -69,3 +69,6 @@ function Time({ date }) {
   )
 }
 ```
+
+> Note: this could be done automatically with a fairly strightforward babel plugin if any wanted to build that...
+> Learn how to do that [here](https://www.youtube.com/watch?v=CFQBHy8RCpg)

--- a/README.md
+++ b/README.md
@@ -72,3 +72,15 @@ function Time({ date }) {
 
 > Note: this could be done automatically with a fairly strightforward babel plugin if any wanted to build that...
 > Learn how to do that [here](https://www.youtube.com/watch?v=CFQBHy8RCpg)
+
+
+## Localization
+tinytime supports localization. Which means you are able to replace months and days by injecting two arrays to the object passed to the tinytime function. Norwegian is used in the example. Default values if localization object is not added is English.
+```js
+const render = template => tinytime(template, {
+   localization: {
+     months: ['januar', 'februar', 'mars', 'april', 'mai', 'juni', 'juli', 'august', 'september', 'oktober', 'november', 'desember'],
+     days: ['mandag', 'tirsdag', 'onsdag', 'torsdag', 'fredag', 'lørdag', 'søndag'],
+   }
+})
+```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ template.render(new Date());
 // The time is 11:10:20PM.
 ```
 
-## Subsitutions
+## Substitutions
 
  * `MMMM` - Full Month (September)
  * `MM` - Partial Month (Sep)
@@ -45,7 +45,7 @@ template string again. That means its important that you aren't recreating the t
 
 Here's an example showing the right and wrong way to use tinytime with React.
 
-Dont do this:
+Don't do this:
 
 ```jsx
 function Time({ date }) {

--- a/__test__/index.spec.js
+++ b/__test__/index.spec.js
@@ -1,11 +1,5 @@
 import tinytime from '../src'
 
-// My birthday!
-const date = new Date('September 24, 1992 021:07:30');
-
-// Helper function to render template with the same date.
-const render = template => tinytime(template).render(date)
-
 describe('tinytime', () => {
   it('should export a function', () => {
     expect(typeof tinytime).toBe('function')
@@ -15,6 +9,12 @@ describe('tinytime', () => {
     expect(typeof template).toBe('object')
   });
   describe('rendering', () => {
+    // My birthday!
+    const date = new Date('September 24, 1992 021:07:30');
+
+    // Helper function to render template with the same date.
+    const render = template => tinytime(template).render(date)
+
     it('should let you render with a date/time', () => {
       expect(render('{h}:{mm}:{ss}{a} on a {dddd}.')).toEqual('9:07:30PM on a Thursday.');
     });
@@ -67,6 +67,41 @@ describe('tinytime', () => {
       )).toEqual(
         'It was 9:07:30PM on September 24th, 1992.'
       )
+    });
+  });
+
+  describe('rendering with custom language', () => {
+    // Someone elses birthday
+    const date = new Date('October 5, 1987 01:00:00');
+
+    const render = template => tinytime(template, {
+      padMonth: true,
+      padDays: true,
+      padHours: true,
+      localization: {
+        months: ['januar', 'februar', 'mars', 'april', 'mai', 'juni', 'juli', 'august', 'september', 'oktober', 'november', 'desember'],
+        days: ['mandag', 'tirsdag', 'onsdag', 'torsdag', 'fredag', 'lørdag', 'søndag'],
+      }
+    }).render(date);
+
+    it('should let you render with a date/time', () => {
+      expect(render('{h}.{mm}.{ss} på en {dddd}.')).toEqual('01.00.00 på en mandag.');
+    });
+
+    it('full months', () => {
+      expect(render('{MMMM}')).toEqual('oktober');
+    });
+
+    it('days of the week', () => {
+      expect(render('{dddd}')).toEqual('mandag');
+    });
+
+    it('user text with subsitutions', () => {
+      expect(render(
+        'Det var {h}.{mm}.{ss} den {DD} {MMMM}, {YYYY}.'
+      )).toEqual(
+        'Det var 01.00.00 den 05 oktober, 1987.'
+      );
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "jsnext:main": "src/index.js",
   "main": "dist/tinytime.js",
   "umd:main": "dist/tinytime.umd.js",
+  "license": "MIT",
   "scripts": {
     "rollup:cjs": "NODE_ENV=production rollup -c rollup.config.js -m -f cjs -n $npm_package_amdName $npm_package_jsnext_main -o $npm_package_main",
     "rollup:umd": "NODE_ENV=production rollup -c rollup.config.js -m -f umd -n $npm_package_amdName $npm_package_jsnext_main -o dist/tinytime.umd.js",

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -72,6 +72,22 @@ function suffix(int: number): string {
       : int + "th";
 }
 
+function getMonths(localization): Array<any> {
+  if (localization && localization.months) {
+    return localization.months;
+  }
+
+  return months;
+}
+
+function getDays(localization): Array<any> {
+  if (localization && localization.days) {
+    return localization.days;
+  }
+
+  return days;
+}
+
 /**
  * The compiler takes in our array of tokens returned from the parser
  * and returns the formed template. It just iterates over the tokens and
@@ -88,6 +104,7 @@ export default function compiler(tokens: Array<Token>, date: Date, options: Tiny
   const seconds = date.getSeconds();
   const minutes = date.getMinutes();
   const day = date.getDate();
+  const { localization } = options;
   let compiled = '';
   let index = 0;
   while (index < tokens.length) {
@@ -101,10 +118,10 @@ export default function compiler(tokens: Array<Token>, date: Date, options: Tiny
         compiled += suffix(day);
         break;
       case PartialMonth:
-        compiled += months[month].slice(0, 3);
+        compiled += getMonths(localization)[month].slice(0, 3);
         break;
       case FullMonth:
-        compiled += months[month];
+        compiled += getMonths(localization)[month];
         break;
       case NumberMonth:
         let mnth = month + 1;
@@ -120,7 +137,7 @@ export default function compiler(tokens: Array<Token>, date: Date, options: Tiny
         compiled += (year + '').slice(2);
         break;
       case DayOfTheWeek:
-        compiled += days[date.getDay() - 1];
+        compiled += getDays(localization)[date.getDay() - 1];
         break;
       case DayOfTheMonth:
         compiled += options.padDays ? paddWithZeros(day) : day

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -52,7 +52,7 @@ const days: Array<Days> = [
 ]
 
 /**
- * Taks an integer and returns a string left padded with
+ * Takes an integer and returns a string left padded with
  * a zero to the left. Used to display minutes and hours (1:01:00PM);
  */
 function paddWithZeros(int: number) : string {

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -72,16 +72,16 @@ function suffix(int: number): string {
       : int + "th";
 }
 
-function getMonths(localization): Array<any> {
-  if (localization && localization.months) {
+function getMonths(localization = {}): Array<any> {
+  if (localization.months) {
     return localization.months;
   }
 
   return months;
 }
 
-function getDays(localization): Array<any> {
-  if (localization && localization.days) {
+function getDays(localization = {}): Array<any> {
+  if (localization.days) {
     return localization.days;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ type TinyTime = {
 export type TinyTimeOptions = {
   padHours?: boolean,
   padDays?: boolean,
+  padMonth?: boolean,
 }
 
 export default function tinytime(template: string, options: TinyTimeOptions = {}): TinyTime {

--- a/src/index.js
+++ b/src/index.js
@@ -10,13 +10,17 @@ export type TinyTimeOptions = {
   padHours?: boolean,
   padDays?: boolean,
   padMonth?: boolean,
+  localization?: {
+    months?: Array<any>,
+    days?: Array<any>,
+  },
 }
 
 export default function tinytime(template: string, options: TinyTimeOptions = {}): TinyTime {
   const templateAST = parser(template);
   return {
     render(date: Date) {
-      return compiler(templateAST, date, options )
+      return compiler(templateAST, date, options)
     }
   }
 }


### PR DESCRIPTION
This is a PoC && haven't touched flow before.

Is this an approach that's acceptable? 

As for the API, should it be a localization object, or should it be flattened to the pad level?
```js
const render = template => tinytime(template, {
   padMonth: true,
   padDays: true,
   padHours: true,
   localization: {
     months: ['januar', 'februar', 'mars', 'april', 'mai', 'juni', 'juli', 'august', 'september', 'oktober', 'november', 'desember'],
     days: ['mandag', 'tirsdag', 'onsdag', 'torsdag', 'fredag', 'lørdag', 'søndag'],
   }
}).render(date);
```

https://github.com/aweary/tinytime/issues/7

EDIT: 
Should update docs