### PR TITLE
Add link to babel plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ function Time({ date }) {
 
 ### Babel Plugin
 
-Using [`babel-plugin-transform-tinytime`](npm.im/babel-plugin-transform-tinytime) you can resolve this efficency concern at compile time. 
+Using [`babel-plugin-transform-tinytime`](http://npm.im/babel-plugin-transform-tinytime) you can resolve this efficency concern at compile time. 

--- a/README.md
+++ b/README.md
@@ -70,5 +70,6 @@ function Time({ date }) {
 }
 ```
 
-> Note: this could be done automatically with a fairly strightforward babel plugin if any wanted to build that...
-> Learn how to do that [here](https://www.youtube.com/watch?v=CFQBHy8RCpg)
+### Babel Plugin
+
+Using [`babel-plugin-transform-tinytime`](npm.im/babel-plugin-transform-tinytime) you can resolve this efficency concern at compile time. 


### PR DESCRIPTION
I put together a quick babel plugin that hoists the tinytime call expressions out of JSXElements and to the program scope. 

