### PR TITLE
Fix rendering Sundays

### DIFF
--- a/__test__/index.spec.js
+++ b/__test__/index.spec.js
@@ -68,5 +68,8 @@ describe('tinytime', () => {
         'It was 9:07:30PM on September 24th, 1992.'
       )
     });
+    it('sundays', () => {
+      expect(tinytime('{dddd}').render(new Date('May 7, 2017'))).toEqual('Sunday')
+    });
   });
 });

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -42,13 +42,13 @@ const months: Array<Month> = [
 ]
 
 const days: Array<Days> = [
+  "Sunday",
   "Monday",
   "Tuesday",
   "Wednesday",
   "Thursday",
   "Friday",
   "Saturday",
-  "Sunday",
 ]
 
 /**
@@ -120,7 +120,7 @@ export default function compiler(tokens: Array<Token>, date: Date, options: Tiny
         compiled += (year + '').slice(2);
         break;
       case DayOfTheWeek:
-        compiled += days[date.getDay() - 1];
+        compiled += days[date.getDay()];
         break;
       case DayOfTheMonth:
         compiled += options.padDays ? paddWithZeros(day) : day


### PR DESCRIPTION
[date.getDay() returns a number from 0-6](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDay) which maps to Sunday-Saturday, currently the code assumes that 7 is equal to Sunday rather than 0 so Sunday renders as undefined.

This fixes it by moving Sunday to the top of the `days` array and not subtracting one from date.getDay()