### PR TITLE
Add babel-plugin-tinytime link

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ function Time({ date }) {
 }
 ```
 
-### Babel Plugin
+### Babel Plugins
 
-Using [`babel-plugin-transform-tinytime`](http://npm.im/babel-plugin-transform-tinytime) you can resolve this efficency concern at compile time. 
+Using one of the plugins below, you can resolve this efficency concern at compile time.
+
+[`babel-plugin-transform-tinytime`](http://npm.im/babel-plugin-transform-tinytime) - Hoists `tinytime` calls out of the JSX render scope.
+
+[`babel-plugin-tinytime`](https://www.npmjs.com/package/babel-plugin-tinytime) - Hoists `tinytime` calls out of the current scope, regardless if its inside JSX or a ordinary function scope. 


### PR DESCRIPTION
Hey folks! I noticed a babel plugin in the docs and would like to add a babel plugin I created to the list if everybody is cool with it.

My plugin takes a general approach to `tinytime` call hoisting. It hoists `tinytime` calls to the outside/program scope regardless if a call is inside a JSX expression or a ordinary function scope. So it takes a much more general approach. I think the plugin `babel-plugin-transform-tinytime` only hoists a call if it's part of a JSX expression.