### PR TITLE
Add invalid date fallback option

### DIFF
--- a/__test__/index.spec.js
+++ b/__test__/index.spec.js
@@ -72,4 +72,13 @@ describe('tinytime', () => {
       expect(tinytime('{dddd}').render(new Date('May 7, 2017'))).toEqual('Sunday')
     });
   });
+  describe('invalid dates', () => {
+    it('allows a string value fallback', () => {
+      const date = new Date('Invalid');
+      const template = tinytime('{H}', { invalid: 'Unknown'  });
+      const rendered = template.render(date);
+
+      expect(rendered).toEqual('Unknown');
+    });
+  });
 });

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -82,6 +82,9 @@ function suffix(int: number): string {
  * @returns {String}
  */
 export default function compiler(tokens: Array<Token>, date: Date, options: TinyTimeOptions): string {
+  if (options.hasOwnProperty('invalid') && isNaN(date)) {
+    return options.invalid;
+  }
   const month = date.getMonth();
   const year = date.getFullYear();
   const hours = date.getHours();

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ export type TinyTimeOptions = {
   padHours?: boolean,
   padDays?: boolean,
   padMonth?: boolean,
+  invalid?: string,
 }
 
 export default function tinytime(template: string, options: TinyTimeOptions = {}): TinyTime {


### PR DESCRIPTION
This commit adds an option to provide a fallback string value if a provided date object is invalid. Otherwise, `tinytime` returns `NaN` for invalid dates.

I wanted to send out a basic implementation first, but I'd be happy to update the changelog, readme, etc. What do you think?

