### PR TITLE
Explain more clearly that days of the month are not padded by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ template.render(new Date());
  * `a` - AM/PM
  
  <sup>1</sup> - you get padded values (e.g. `09` instead of `9`) by passing the following options:
- * `padMonth` for hours
- * `padMonth` for days
+ * `padHours` for hours
+ * `padDays` for days
  * `padMonth` for months
  
  ```js

--- a/README.md
+++ b/README.md
@@ -28,18 +28,23 @@ template.render(new Date());
  * `YYYY` - Full Year (1992)
  * `YY` - Partial Year (92)
  * `dddd` - Day of the Week (Monday)
- * `DD` - Day of the Month (24)
- * `Do` - Day (24th)
- * `h` - Hours - 12h format
- * `H` - Hours - 24h format
+ * `DD` - Day of the Month (8) <sup>1</sup>
+ * `Do` - Day (8th)
+ * `h` - Hours - 12h format <sup>1</sup>
+ * `H` - Hours - 24h format <sup>1</sup>
  * `mm` - Minutes (zero padded)
  * `ss` - Seconds (zero padded)
  * `a` - AM/PM
  
- <sup>1</sup> - you get padded months (`09` instead of `9`) by passing in the `padMonth` option.
+ <sup>1</sup> - you get padded values (e.g. `09` instead of `9`) by passing the following options:
+ * `padMonth` for hours
+ * `padMonth` for days
+ * `padMonth` for months
  
  ```js
- const template = tinytime('{Mo}', { padMonth: true })
+ const opts = { padHours: true, padMonth: true, padDays: true};
+ const template = tinytime('{YYYY}-{Mo}-{DD} {h}:{mm}:{ss}', opts);
+ // 1992-09-08 09:07:30
  ```
 
 

--- a/__test__/index.spec.js
+++ b/__test__/index.spec.js
@@ -1,7 +1,7 @@
 import tinytime from '../src'
 
 // My birthday!
-const date = new Date('September 24, 1992 021:07:30');
+const date = new Date('September 8, 1992 021:07:30');
 
 // Helper function to render template with the same date.
 const render = template => tinytime(template).render(date)
@@ -16,7 +16,7 @@ describe('tinytime', () => {
   });
   describe('rendering', () => {
     it('should let you render with a date/time', () => {
-      expect(render('{h}:{mm}:{ss}{a} on a {dddd}.')).toEqual('9:07:30PM on a Thursday.');
+      expect(render('{h}:{mm}:{ss}{a} on a {dddd}.')).toEqual('9:07:30PM on a Tuesday.');
     });
     it('full months', () => {
       expect(render('{MMMM}')).toEqual('September');
@@ -39,10 +39,18 @@ describe('tinytime', () => {
       expect(render('{YY}')).toEqual('92');
     })
     it('days of the week', () => {
-      expect(render('{dddd}')).toEqual('Thursday');
+      expect(render('{dddd}')).toEqual('Tuesday');
     });
-    it('day of the month', () => {
-      expect(render('{Do}')).toEqual('24th');
+    it('days of the month', () => {
+      expect(render('{DD}')).toEqual('8');
+    });
+    it('padded days of the month', () => {
+      const template = tinytime('{DD}', { padDays: true });
+      const rendered = template.render(date);
+      expect(rendered).toEqual('08');
+    });
+    it('days', () => {
+      expect(render('{Do}')).toEqual('8th');
     });
     it('times', () => {
       expect(render('{h}:{mm}:{ss}{a}')).toEqual('9:07:30PM');
@@ -65,7 +73,7 @@ describe('tinytime', () => {
       expect(render(
         'It was {h}:{mm}:{ss}{a} on {MMMM} {Do}, {YYYY}.'
       )).toEqual(
-        'It was 9:07:30PM on September 24th, 1992.'
+        'It was 9:07:30PM on September 8th, 1992.'
       )
     });
     it('sundays', () => {


### PR DESCRIPTION
I have improved the `README.md` file to explain better that hours and days of the month are not padded by default. Since documentation uses 24th and there is a note about padding only for months, some users may think the rest of the components are padded automatically.

In addition, I have added some unit tests to verify that the days of the month are properly padded in `index.spec.js`. My initial intention was to avoid changes in the rest of the file, but I thought that keeping a single date for all the tests as you were doing was more appropriate, so I have changed the day of the month and updated the unit tests accordingly.

By the way, thank you  for this library; it is very useful for the projects I work on.